### PR TITLE
add support list - to replace 'building a co-op advice and/or training

### DIFF
--- a/advice/support.md
+++ b/advice/support.md
@@ -1,0 +1,7 @@
+# Relevant organisations - potential support
++ [Altgen](http://altgen.coop/) - we already know Constance
++ [The Hive](https://www.uk.coop/the-hive/)
++ [Seeds for Change](http://www.seedsforchange.org.uk/)
++ [Co-operatives UK](https://www.uk.coop/developing-co-ops/start-co-operative) - [London Co-op](https://ldn.coop/start-a-co-op/start-a-worker-co-op/)
++ [Stir to Action](https://www.stirtoaction.com/workshops)
++ [Cooperative Technologists](https://www.coops.tech/) - started by Outlandish as "[the Megazord](https://outlandish.com/blog/co-op-of-software-co-ops-arise-er-megazord/)"


### PR DESCRIPTION
This is just a start :smile: 

Fixes #19