### PR TITLE
add history pre-this repo

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,0 +1,14 @@
+# History: timeline before the creation of this repo
++ November (Week 5 of FAC9?) - Birth of the idea: lunch with Ines to ask about the DWYL-FAC financial (and cultural) relationship. Found out that DWYL was leaving.
++ November/December 2016 (Week 7 of FAC9?) - discussed the idea with @bradreeder & @sohilpandya. Sohil told me about the last time a FAC agency was attempted
++ Early January - my questions about FAC's funding model - https://github.com/foundersandcoders/london-programme/issues/143 & https://github.com/foundersandcoders/london-programme/issues/140
++ Dates? (between weeks 12-16 of FAC9) - reached out to others who might share the same vision, whilst keeping our numbers realistic: @sohilpandya @nogainbar @des-des (more experienced than current students)
++ January 21st - Founders and Coders AGM - met Rebecca, had first introduction to consensus based decision making. This was when the idea became a "coop" agency.
++ January 25th - met Ian Bellchambers at an [International Tech for Good meetup](https://www.meetup.com/techforgood/events/236415497/) (@jsms90). Invitation to come in to Outlandish & discuss ideas
++ Date? - Met with Dan & Ines to ask for their input / advice on us forming an agency & whether I could shadow Ines at DWYL (@bradreeder & @jsms90)
++ Most Sundays during February - brainstorming and some light research (@bradreeder & @jsms90)
++ 14th February - met with Outlandish at their offices (@bradreeder & @jsms90)
++ 16th February - invited by Outlandish to Open Tech's [post-conference networking drinks](https://2017.open.coop/sessions/networking-drinks/) (@bradreeder & @jsms90)
++ End of March - reached out to others who might share the same vision: @emilyb7 & Marko (recent graduates)
++ 22nd March - Agency formation meeting (@sohilpandya @bradreeder @jsms90 @nogainbar @des-des @emilyb7 @sofer Marko)
++ 23rd March - [Freeing the freelancer: cooperative solutions](https://www.eventbrite.com/e/freeing-the-freelancer-cooperative-solutions-tickets-32497707518#) by Altgen, at NewSpeak House (@nogainbar & @jsms90)


### PR DESCRIPTION
In the interest of keeping our issues actionable and our backlog clean, I'm converting our timeline from before the creation of this repo into a document :smile: 

Fixes #17